### PR TITLE
Scanr idr fixes

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -518,7 +518,7 @@ public class ScanrReader extends FormatReader {
       if (next == originalIndex &&
         missingWellFiles == nSlices * nTimepoints * nChannels * nPos)
       {
-        wellNumbers.remove(well);
+        next += nSlices * nTimepoints * nChannels * nPos;
       }
     }
     nWells = wellNumbers.size();

--- a/components/formats-gpl/src/loci/formats/in/ScanrReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScanrReader.java
@@ -544,7 +544,12 @@ public class ScanrReader extends FormatReader {
     }
 
     reader = new MinimalTiffReader();
-    reader.setId(tiffs[0]);
+    for (String tiff : tiffs) {
+      if (tiff != null) {
+        reader.setId(tiff);
+	break;
+      }
+    }
     int sizeX = reader.getSizeX();
     int sizeY = reader.getSizeY();
     int pixelType = reader.getPixelType();


### PR DESCRIPTION
See https://github.com/idr-contrib/community/issues/5 and https://github.com/openmicroscopy/bioformats/pull/3083

The custom ScanrReader handling of missing planes that were implemented for the [secretion study](https://idr.openmicroscopy.org/webclient/?show=screen-251) were lost when IDR Bio-Formats was upgraded to 5.4.x.

This should restore the two necessary commits to handle missing files as black planes.