### PR TITLE
Move ScreenReader to the top of the list

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -2,6 +2,7 @@
 # available to Bio-Formats, and the order in which they should be used.
 # Please do not edit unless you know what you are doing (see reader-guide.txt).
 
+loci.formats.in.ScreenReader[type=external]         # .screen
 loci.formats.in.FilePatternReader     # pattern
 
 # readers for compressed/archive files
@@ -13,7 +14,6 @@ loci.formats.in.JPEGReader            # jpg, jpeg [javax.imageio]
 
 # external readers with unique file extensions
 loci.formats.in.SlideBook6Reader[type=external]      # sld
-loci.formats.in.ScreenReader[type=external]         # .screen
 
 # standalone readers with unique file extensions
 loci.formats.in.PGMReader             # pgm


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/5896#issuecomment-435980414

Some of the internal mechanism of FilePatternReader result in incompatible states of FormatReader.isMetadataFiltered() leading to memo file invalidation.