### PR TITLE
Columbus: copy delegate reader's CoreMetadata instead of using directly

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -293,7 +293,10 @@ public class ColumbusReader extends FormatReader {
 
     reader = new MinimalTiffReader();
     reader.setId(tmpPlanes[0].file);
-    core = reader.getCoreMetadataList();
+    core.clear();
+    for (CoreMetadata c : reader.getCoreMetadataList()) {
+      core.add(new CoreMetadata(c));
+    }
 
     CoreMetadata m = core.get(0);
 


### PR DESCRIPTION
See https://github.com/IDR/idr0056-stojic-lncrnas/issues/3

--exclude