### PR TITLE
Zeiss CZI: prevent index out of bounds when population positions

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ZeissCZIReader.java
@@ -2136,7 +2136,7 @@ public class ZeissCZIReader extends FormatReader {
           }
           if (positions.getLength() == 0 && (mosaics <= 1 || (prestitched != null && prestitched))) {
             positions = scene.getElementsByTagName("CenterPosition");
-            if (positions.getLength() > 0) {
+            if (positions.getLength() > 0 && nextPosition < positionsX.length) {
               Element position = (Element) positions.item(0);
               String[] pos = position.getTextContent().split(",");
               positionsX[nextPosition] = new Length(DataTools.parseDouble(pos[0]), UNITS.MICROM);


### PR DESCRIPTION
Companion to https://github.com/openmicroscopy/bioformats/pull/3412 opened against the IDR fork of Bio-Formats

This PR is primarily intended to test the reading of `idr0011/screenD` using the `ScreenReader` and should not be merged. The tag for the upcoming upstream patch release of Bio-Formats should be merged instead.