### PR TITLE
Add deployment mechanism for uploading artifacts to OME Artifactory

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,18 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+      <server>
+        <id>ome.staging</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+      <server>
+        <id>ome.snapshots</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,19 @@ env:
 matrix:
   fast_finish: true
   exclude:
-  - jdk: oraclejdk11
-    env: BUILD=ant
   - jdk: openjdk11
-    env: BUILD=ant
-  - jdk: oraclejdk8
     env: BUILD=ant
   - jdk: openjdk8
     env: BUILD=maven
 
 script:
   - ./tools/test-build $BUILD
+
+deploy:
+  provider: script
+  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
+  skip_cleanup: true
+  on:
+    jdk: openjdk8
+    all_branches: true
+    tags: false


### PR DESCRIPTION
The upload of SNAPSHOT and release artifacts to OME Artifactory is currently performed:

- via a Jenkins job for the OME Bio-Formats
- manually for IDR Bio-Formats

This PR proposes to use the Travis CI deployment mechanism in IDR. This strategy is already used done in https://github.com/ome/bio-formats-examples and https://github.com/ome/bio-formats-documentation/.