### PR TITLE
Flex: Prevent divide by zero exception

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FlexReader.java
+++ b/components/formats-gpl/src/loci/formats/in/FlexReader.java
@@ -1361,6 +1361,10 @@ public class FlexReader extends FormatReader {
 
         nFiles = files.size();
 
+        if (runCount == 0) runCount = 1;
+        if (nFiles == 0) nFiles = 1;
+        if (runCount > nFiles) runCount = 1;
+
         String[] sortedFiles = files.toArray(new String[files.size()]);
         Arrays.sort(sortedFiles);
         files.clear();
@@ -1437,7 +1441,7 @@ public class FlexReader extends FormatReader {
           // should be taken from the XML
           boolean parsedXML = parseFlexFile(currentWell, row, col, nFiles == 1 ? -1 : field, firstFile, store);
           s.close();
-	  if (firstFile && parsedXML) firstFile = false;
+          if (firstFile && parsedXML) firstFile = false;
         }
         currentWell++;
       }


### PR DESCRIPTION
Fix for divide by zero ArithmeticException which has been reported on idr0072 (see https://idr-redmine.openmicroscopy.org/issues/116#note-29).

This minimal change should allow for all the plates to be imported without any exceptions