### PR TITLE
BDV: Fix for tiled reading

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -294,26 +294,26 @@ public class BDVReader extends FormatReader {
         short[][] data = (short[][]) image;
         short[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(rowData[i + x], buf, base + 2 * i, 2, little);
+          DataTools.unpackBytes(rowData[i], buf, base + 2 * i, 2, little);
         }
       } else if (image instanceof int[][]) {
         int[][] data = (int[][]) image;
         int[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(rowData[i + x], buf, base + i * 4, 4, little);
+          DataTools.unpackBytes(rowData[i], buf, base + i * 4, 4, little);
         }
       } else if (image instanceof float[][]) {
         float[][] data = (float[][]) image;
         float[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          int v = Float.floatToIntBits(rowData[i + x]);
+          int v = Float.floatToIntBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i * 4, 4, little);
         }
       } else if (image instanceof double[][]) {
         double[][] data = (double[][]) image;
         double[] rowData = data[row];
         for (int i = 0; i < w; i++) {
-          long v = Double.doubleToLongBits(rowData[i + x]);
+          long v = Double.doubleToLongBits(rowData[i]);
           DataTools.unpackBytes(v, buf, base + i * 8, 8, little);
         }
       }

--- a/components/formats-gpl/src/loci/formats/in/BDVReader.java
+++ b/components/formats-gpl/src/loci/formats/in/BDVReader.java
@@ -277,7 +277,7 @@ public class BDVReader extends FormatReader {
     lastChannel = getZCTCoords(no)[1];
 
     // pixel data is stored in XYZ blocks
-    Object image = getImageData(no, y, h);
+    Object image = getImageData(no, x, y, w, h);
 
     boolean little = isLittleEndian();
 
@@ -365,13 +365,12 @@ public class BDVReader extends FormatReader {
     }
   }
 
-  private Object getImageData(int no, int y, int height) throws FormatException
+  private Object getImageData(int no, int x, int y, int width, int height) throws FormatException
   {
     int[] zct = getZCTCoords(no);
     int zslice = zct[0];
     int channel = zct[1];
     int time = zct[2];
-    int width = getSizeX();
     
     int seriesIndex = series;
     int requiredResolution = getResolution();
@@ -422,7 +421,7 @@ public class BDVReader extends FormatReader {
 
     int elementSize = jhdf.getElementSize(imagePath.pathToImageData);
 
-    int[] arrayOrigin = new int[] {zslice, y, 0};
+    int[] arrayOrigin = new int[] {zslice, y, x};
     int[] arrayDimension = new int[] {1, height, width};
 
     MDIntArray subBlock = jhdf.readIntBlockArray(imagePath.pathToImageData, arrayOrigin, arrayDimension);


### PR DESCRIPTION
Backports performance improvements from https://github.com/ome/bioformats/pull/3549 into the IDR fork of Bio-Formats

Note this ignores other improvements made to BDV in https://github.com/ome/bioformats/pull/3443 and https://github.com/ome/bioformats/pull/3575 as these contain memo-breaking change. After a closer examination, I convinced myself that the issues reported in https://github.com/ome/bioformats/issues/3567 only affected the daily CI builds. 

With this PR the expectation is that immediately:

- the BDV reader in mainline OME BIo-Formats has proper support for physical size parsing and improved tiled reading as well as the required changes for automated non-regression testing
- the BDV reader in the IDR fork only has the improved tiled reading changes. In the context of the `idr0048`, the voxel size if 1 pixel and will need manual overriding.

In other terms, this is a best effort to contain the amount of changes required in the scope of the IDR submission, to quickly deploy them onto IDR and publish the study without requiring a complete cache regeneration process.
As discussed on Monday, the hope is to schedule another round of merging of Bio-Formats 6.x into this fork to reduce the divergence and maintenance costs and benefit from all formats improvements made in the mainline.