### PR TITLE
ScreenReader: close sub-readers to prevent file resources leaking

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -410,6 +410,7 @@ public class ScreenReader extends FormatReader {
         ClassList<IFormatReader> chosenReaders =
           new ClassList<IFormatReader>(IFormatReader.class);
         chosenReaders.addClass(chosenReader);
+        reader.close();
         stitcher.setReaderClassList(chosenReaders);
         // Re-initialize
         reader.setId(files[well][0]);

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -189,10 +189,12 @@ public class ScreenReader extends FormatReader {
     int spotIndex = seriesMap.get(getCoreIndex());
     int fileIndex = fileIndexes[spotIndex][no][0];
     int planeIndex = fileIndexes[spotIndex][no][1];
-    reader.setId(files[spotIndex][fileIndex]);
-    buf = reader.openBytes(planeIndex, buf, x, y, w, h);
-    reader.close();
-    return buf;
+    try {
+      reader.setId(files[spotIndex][fileIndex]);
+      return reader.openBytes(planeIndex, buf, x, y, w, h);
+    } finally {
+      reader.close();
+    }
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */

--- a/components/formats-gpl/src/loci/formats/in/ScreenReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ScreenReader.java
@@ -190,7 +190,9 @@ public class ScreenReader extends FormatReader {
     int fileIndex = fileIndexes[spotIndex][no][0];
     int planeIndex = fileIndexes[spotIndex][no][1];
     reader.setId(files[spotIndex][fileIndex]);
-    return reader.openBytes(planeIndex, buf, x, y, w, h);
+    buf = reader.openBytes(planeIndex, buf, x, y, w, h);
+    reader.close();
+    return buf;
   }
 
   /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */


### PR DESCRIPTION
Recent work on the Zarr HCS specification as well as recent submissions have demonstrated that we have a file leak in `ScreenReader` as resources are not been closed on access leading eventually to `Too many open files` exceptions.

Using the `file-leak-detector`, I have been able to track the issue down the `initFile` step and more specifically the logic for selecting the sub-reader.

Using the following minimal screen example

```
sbesson@ls30630:bioformats (screenreader_fileleak) $ ls /tmp/data/screen/
A01.tiff	A02.tiff	minimal.screen
sbesson@ls30630:bioformats (screenreader_fileleak) $ cat /tmp/data/screen/minimal.screen 
[Plate]
Rows = 1
Columns = 2
Fields = 1

[Well 0]
Row = 0
Column = 0
Field_0 = A01.tiff

[Well 1]
Row = 0
Column = 1
Field_0 = A02.tiff
```

Running `ant gen-config` generates a configuration but `ant test-automated` fails early due unclosed file handle with the current HEAD of the `master` branch. With fe7b208 included, the tests are running and passing successfully except for `testIsThisType` which is a separate issue, probably not worth addressing as this reader is specific to the IDR fork.

